### PR TITLE
Fail decoding if the base64 string isn't properly terminated

### DIFF
--- a/base64.h
+++ b/base64.h
@@ -192,7 +192,7 @@ class Base64 {
       }
     }
 
-    return (out == (out_begin + decoded_length));
+    return *input == '=' && (out == (out_begin + decoded_length));
   }
 
   static int DecodedLength(const char *in, size_t in_length) {


### PR DESCRIPTION
I used this in a project today and I tested decoding "Hello World" as base64, hoping it would return an error. But it did not. It looks like all Base64 strings should end with =, so I've added a check for that and if it's not there it returns false.